### PR TITLE
chore: test team member enforcement

### DIFF
--- a/teams/dummy.toml
+++ b/teams/dummy.toml
@@ -1,0 +1,7 @@
+name = "dummy"
+members = [
+    "dependabot-bot",
+]
+repos = [
+    "governance",
+]


### PR DESCRIPTION
This creates a dummy team (using `dependabot-bot` as the only member) to check whether the validate-pr workflow is functioning correctly.