### PR TITLE
feat: add visualizer for governance data

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -68,6 +68,6 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run Governance Validator
-        run: cargo run --release --bin governance
+        run: RUST_LOG=info cargo run --release --bin governance
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/visualize.yml
+++ b/.github/workflows/visualize.yml
@@ -1,0 +1,65 @@
+name: Visualize
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "contributors/**"
+      - "repos/**"
+      - "teams/**"
+      - "meta/visualizer/**"
+  pull_request:
+    paths:
+      - "contributors/**"
+      - "repos/**"
+      - "teams/**"
+      - "meta/visualizer/**"
+  workflow_dispatch:
+
+jobs:
+  build-website:
+    name: Build Website
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build visualizer
+        run: |
+          cd meta/visualizer
+          cargo build --release
+          cargo run --release
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "meta/visualizer/dist"
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build-website
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 /target
+**/dist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "askama"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+dependencies = [
+ "askama_derive",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
+dependencies = [
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +156,15 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -1085,6 +1136,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,6 +1627,18 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "visualizer"
+version = "0.1.0"
+dependencies = [
+ "askama",
+ "glob",
+ "governance",
+ "serde",
+ "serde_json",
+ "toml",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["meta/validators/*"]
+members = ["meta/validators/*", "meta/visualizer"]
 
 [workspace.package]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ In this document, 'ScottyLabs' will refer to the GitHub organization at https://
 ├── meta
 │   ├── infra      # Terraform code for applying changes
 │   ├── schemas    # JSON schemas for validation
-│   └── validators # Rust-based validation tools
+│   ├── validators # Rust-based validation tools
+│   └── visualizer # Force graph for visualizing relationships
 ├── repos          # Team definitions with members and repos
 └── teams          # Repository definitions with metadata
 ```

--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ Create a new TOML file in `teams/` with the team name as the filename, e.g. `cmu
 ```toml
 name = "cmucourses"
 members = [
-    "your-username"
+    "your-username" # >= 1 member (yourself)
 ]
 repos = [
-    "cmucourses"
+    "cmucourses" # >= 1 repo
 ]
 ```
 

--- a/meta/validators/governance/src/checks.rs
+++ b/meta/validators/governance/src/checks.rs
@@ -3,10 +3,9 @@ use std::collections::HashMap;
 use anyhow::{Result, anyhow};
 use colored::Colorize;
 use futures::{StreamExt, stream::FuturesUnordered};
+use governance::model::{Contributor, Repo, Team, ValidationError, ValidationWarning};
 use log::info;
 use reqwest::{Client, StatusCode};
-
-use crate::model::{Contributor, Repo, Team, ValidationError, ValidationWarning};
 
 pub fn validate_file_names(
     contributors: &HashMap<String, Contributor>,

--- a/meta/validators/governance/src/lib.rs
+++ b/meta/validators/governance/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod loader;
+pub mod model;

--- a/meta/validators/governance/src/main.rs
+++ b/meta/validators/governance/src/main.rs
@@ -1,12 +1,10 @@
 mod checks;
-mod loader;
-mod model;
 
 use anyhow::{Result, anyhow};
 use checks::{validate_cross_references, validate_file_names, validate_github_users};
 use colored::Colorize;
-use loader::{load_contributors, load_repos, load_teams};
-use model::{
+use governance::loader::{load_contributors, load_repos, load_teams};
+use governance::model::{
     FileValidationMessages, ValidationError, ValidationReport, ValidationStatistics,
     ValidationWarning,
 };

--- a/meta/validators/governance/src/model.rs
+++ b/meta/validators/governance/src/model.rs
@@ -14,11 +14,14 @@ pub struct Team {
     pub repos: Vec<String>,
 }
 
+// we do not care about enforcing website vs. websites exclusivity here
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Repo {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub website: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub websites: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 }

--- a/meta/visualizer/Cargo.toml
+++ b/meta/visualizer/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "visualizer"
+version = "0.1.0"
+edition = "2024"
+license.workspace = true
+
+[dependencies]
+askama = { version = "0.14.0", features = ["serde_json"] }
+glob = "0.3.2"
+governance = { path = "../validators/governance" }
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
+toml = "0.8.22"

--- a/meta/visualizer/src/graph.rs
+++ b/meta/visualizer/src/graph.rs
@@ -1,0 +1,225 @@
+use governance::model::{Contributor, Repo, Team};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::{
+    collections::{HashMap, HashSet},
+    error::Error,
+};
+
+#[derive(Serialize, Deserialize)]
+struct GraphNode {
+    id: String,
+    name: String,
+    #[serde(rename = "nodeType")]
+    node_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    github: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    website: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    websites: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    members: Option<Vec<String>>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct GraphLink {
+    source: String,
+    target: String,
+    #[serde(rename = "linkType")]
+    link_type: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct GraphData {
+    nodes: Vec<GraphNode>,
+    links: Vec<GraphLink>,
+}
+
+fn build_contributors_teams_graph(
+    contributors: &HashMap<String, Contributor>,
+    teams: &HashMap<String, Team>,
+) -> Result<Value, Box<dyn Error>> {
+    let mut nodes = Vec::new();
+    let mut links = Vec::new();
+
+    // Add contributor nodes
+    for (id, contributor) in contributors {
+        nodes.push(GraphNode {
+            id: id.clone(),
+            name: contributor.name.clone(),
+            node_type: "Contributor".to_string(),
+            github: Some(contributor.github.clone()),
+            description: None,
+            website: None,
+            websites: None,
+            members: None,
+        });
+    }
+
+    // Add team nodes and team-member links
+    for (id, team) in teams {
+        nodes.push(GraphNode {
+            id: id.clone(),
+            name: team.name.clone(),
+            node_type: "Team".to_string(),
+            github: None,
+            description: None,
+            website: None,
+            websites: None,
+            members: Some(team.members.clone()),
+        });
+
+        for member_id in &team.members {
+            links.push(GraphLink {
+                source: id.clone(),
+                target: member_id.clone(),
+                link_type: "team-member".to_string(),
+            });
+        }
+    }
+
+    Ok(json!({
+        "nodes": nodes,
+        "links": links
+    }))
+}
+
+fn build_teams_repos_graph(
+    teams: &HashMap<String, Team>,
+    repos: &HashMap<String, Repo>,
+) -> Result<Value, Box<dyn Error>> {
+    let mut nodes = Vec::new();
+    let mut links = Vec::new();
+
+    // Add team nodes
+    for (id, team) in teams {
+        nodes.push(GraphNode {
+            id: id.clone(),
+            name: team.name.clone(),
+            node_type: "Team".to_string(),
+            github: None,
+            description: None,
+            website: None,
+            websites: None,
+            members: Some(team.members.clone()),
+        });
+    }
+
+    // Add repo nodes
+    for (id, repo) in repos {
+        nodes.push(GraphNode {
+            id: id.clone(),
+            name: repo.name.clone(),
+            node_type: "Repo".to_string(),
+            github: None,
+            description: repo.description.clone(),
+            website: repo.website.clone(),
+            websites: repo.websites.clone(),
+            members: None,
+        });
+    }
+
+    // Add team-repo links
+    for (team_id, team) in teams {
+        for repo_id in &team.repos {
+            links.push(GraphLink {
+                source: team_id.clone(),
+                target: repo_id.clone(),
+                link_type: "team-repo".to_string(),
+            });
+        }
+    }
+
+    Ok(json!({
+        "nodes": nodes,
+        "links": links
+    }))
+}
+
+fn build_contributors_repos_graph(
+    contributors: &HashMap<String, Contributor>,
+    teams: &HashMap<String, Team>,
+    repos: &HashMap<String, Repo>,
+) -> Result<Value, Box<dyn Error>> {
+    let mut nodes = Vec::new();
+    let mut links = Vec::new();
+
+    // Map to track which repos each contributor is connected to (via teams)
+    let mut contributor_to_repos: HashMap<String, HashSet<String>> = HashMap::new();
+
+    // Build the contributor-team-repo connection map
+    for team in teams.values() {
+        for member_id in &team.members {
+            for repo_id in &team.repos {
+                contributor_to_repos
+                    .entry(member_id.clone())
+                    .or_default()
+                    .insert(repo_id.clone());
+            }
+        }
+    }
+
+    // Add contributor nodes
+    for (id, contributor) in contributors {
+        nodes.push(GraphNode {
+            id: id.clone(),
+            name: contributor.name.clone(),
+            node_type: "Contributor".to_string(),
+            github: Some(contributor.github.clone()),
+            description: None,
+            website: None,
+            websites: None,
+            members: None,
+        });
+    }
+
+    // Add repo nodes
+    for (id, repo) in repos {
+        nodes.push(GraphNode {
+            id: id.clone(),
+            name: repo.name.clone(),
+            node_type: "Repo".to_string(),
+            github: None,
+            description: repo.description.clone(),
+            website: repo.website.clone(),
+            websites: repo.websites.clone(),
+            members: None,
+        });
+    }
+
+    // Add contributor-repo links
+    for (contributor_id, repo_ids) in contributor_to_repos {
+        for repo_id in repo_ids {
+            links.push(GraphLink {
+                source: contributor_id.clone(),
+                target: repo_id.clone(),
+                link_type: "contributor-repo".to_string(),
+            });
+        }
+    }
+
+    Ok(json!({
+        "nodes": nodes,
+        "links": links
+    }))
+}
+
+pub fn build_graph_data(
+    contributors: HashMap<String, Contributor>,
+    teams: HashMap<String, Team>,
+    repos: HashMap<String, Repo>,
+) -> Result<Value, Box<dyn Error>> {
+    // Build filtered views
+    let default = build_contributors_teams_graph(&contributors, &teams)?;
+    let teams_repos = build_teams_repos_graph(&teams, &repos)?;
+    let contributors_repos = build_contributors_repos_graph(&contributors, &teams, &repos)?;
+
+    Ok(json!({
+        "default": default,
+        "teamsRepos": teams_repos,
+        "contributorsRepos": contributors_repos
+    }))
+}

--- a/meta/visualizer/src/main.rs
+++ b/meta/visualizer/src/main.rs
@@ -1,0 +1,33 @@
+mod graph;
+
+use askama::Template;
+use governance::loader::{load_contributors, load_repos, load_teams};
+use graph::build_graph_data;
+use serde_json::Value;
+use std::{error::Error, fs, path::Path};
+
+#[derive(Template)]
+#[template(path = "index.html")]
+struct GovernanceTemplate {
+    graph_data: Value,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Create output directory
+    let dist_dir = Path::new("dist");
+    fs::create_dir_all(dist_dir)?;
+
+    // Load governance data
+    let contributors = load_contributors()?;
+    let teams = load_teams()?;
+    let repos = load_repos()?;
+
+    let graph_data = build_graph_data(contributors, teams, repos)?;
+
+    // Render template
+    let template = GovernanceTemplate { graph_data };
+    let html = template.render()?;
+
+    fs::write("dist/index.html", html)?;
+    Ok(())
+}

--- a/meta/visualizer/templates/index.html
+++ b/meta/visualizer/templates/index.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="ScottyLabs Governance Visualizer" />
+
+    <title>Visualizer</title>
+    <script src="https://unpkg.com/d3@7"></script>
+    <script src="https://unpkg.com/force-graph"></script>
+
+    <style>
+        body,
+        html {
+            margin: 0;
+            padding: 0;
+            width: 100%;
+            height: 100%;
+            overflow: hidden;
+        }
+
+        #graph {
+            width: 100%;
+            height: 100vh;
+        }
+
+        #view-selector {
+            position: absolute;
+            top: 20px;
+            right: 20px;
+            z-index: 10;
+        }
+    </style>
+</head>
+
+<body>
+    <div id="graph"></div>
+    <div id="view-selector">
+        <select id="relationship-filter">
+            <option value="default" selected>Contributors & Teams</option>
+            <option value="contributorsRepos">Contributors & Repos</option>
+            <option value="teamsRepos">Teams & Repos</option>
+        </select>
+    </div>
+
+    <script>
+        const datasets = {{ graph_data | json | safe }};
+
+        const OFFSET = 10;
+        const NODE_COLORS = {
+            Contributor: "#4CAF50", // Green
+            Team: "#2196F3",        // Blue
+            Repo: "#F44336"         // Red
+        };
+
+        // Initialize with default graph
+        const graph = ForceGraph()
+            (document.getElementById("graph"))
+            .nodeColor(node => NODE_COLORS[node.nodeType])
+            .nodeVal(node => {
+                // Size node based on number of connections
+                const links = graph.graphData().links;
+                const connectionCount = links.filter(link =>
+                    link.source.id === node.id || link.target.id === node.id
+                ).length;
+                return 4 + connectionCount * 1.5;
+            });
+
+        // Prevent node overlap
+        graph.d3Force('collide', d3.forceCollide().radius(n => graph.nodeVal()(n) + OFFSET));
+
+        // Add links
+        graph.onNodeClick(node => {
+            const n = encodeURIComponent(node.id);
+            let url = '';
+
+            switch (node.nodeType) {
+                case "Contributor":
+                    url = `https://github.com/orgs/ScottyLabs/people/${n}`;
+                    break;
+                case "Team":
+                    url = `https://github.com/orgs/ScottyLabs/teams/${n}`;
+                    break;
+                case "Repo":
+                    url = `https://github.com/ScottyLabs/${n}`;
+                    break;
+            }
+
+            if (url) window.open(url, "_blank");
+        });
+
+        graph.onNodeHover(node => {
+            document.body.style.cursor = node ? 'pointer' : '';
+        });
+
+        // Initial render + select listener
+        function updateGraph(datasetKey) {
+            graph.graphData(datasets[datasetKey]);
+        }
+
+        updateGraph("default");
+
+        document.getElementById("relationship-filter").addEventListener("change", function (e) {
+            updateGraph(e.target.value);
+        });
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
This separates out some of the components of the `governance` validator into a library and uses them alongside `askama` to create a simple visualization using `force-graph`. It also includes a workflow which (hopefully) deploys it to GitHub Pages.

The visualizer can be configured to display team-repo relationships, contributor-team relationships, and contributor-repo relationships. 